### PR TITLE
search input and output modified

### DIFF
--- a/src/java/searcher/ClueWebRetriever.java
+++ b/src/java/searcher/ClueWebRetriever.java
@@ -6,9 +6,6 @@
 package searcher;
 
 import indexer.TrecDocIndexer;
-import javax.json.JsonArray;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.Query;

--- a/src/java/searcher/ClueWebRetriever.java
+++ b/src/java/searcher/ClueWebRetriever.java
@@ -8,6 +8,7 @@ package searcher;
 import indexer.TrecDocIndexer;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.Query;
@@ -24,16 +25,13 @@ public class ClueWebRetriever extends WT10GRetriever {
     }
     
     @Override
-    JsonArray constructJSONForDoc(Query q, int docid) throws Exception {
+    JsonObjectBuilder constructJSONForDoc(Query q, int docid) throws Exception {
         Document doc = reader.document(docid);
-        
-        JsonArrayBuilder arrayBuilder = factory.createArrayBuilder();
         JsonObjectBuilder objectBuilder = factory.createObjectBuilder();
         objectBuilder.add("title", doc.get(WTDocument.WTDOC_FIELD_TITLE));
         objectBuilder.add("url", doc.get(WTDocument.WTDOC_FIELD_URL));
         objectBuilder.add("id", doc.get(TrecDocIndexer.FIELD_ID));
-        arrayBuilder.add(objectBuilder);
-        return arrayBuilder.build();
+        return objectBuilder;
     }
     
 }

--- a/src/java/searcher/IntRange.java
+++ b/src/java/searcher/IntRange.java
@@ -1,0 +1,55 @@
+
+package searcher;
+
+import java.util.Iterator;
+
+/**
+ * Utility class for an iterable integral close-open range
+ */
+public class IntRange implements Iterable<Integer> {
+
+    private final int inclusiveStart;
+    private final int exclusiveEnd;
+
+    public IntRange(int inclusiveStart, int exclusiveEnd) {
+        this.inclusiveStart = inclusiveStart;
+        this.exclusiveEnd = exclusiveEnd;
+    }
+    
+    public IntRange limit(int inclusiveStart, int exclusiveEnd) {
+        return new IntRange(
+                Math.max(inclusiveStart, this.inclusiveStart), 
+                Math.min(exclusiveEnd, this.exclusiveEnd)
+        );
+    }
+
+    public int getInclusiveStart() {
+        return inclusiveStart;
+    }
+
+    public int getExclusiveEnd() {
+        return exclusiveEnd;
+    }
+
+    @Override
+    public Iterator<Integer> iterator() {
+        return new Iterator<Integer>() {
+            private int count = inclusiveStart;
+            
+            @Override
+            public boolean hasNext() {
+                return count < exclusiveEnd;
+            }
+            
+            @Override
+            public Integer next() {
+                return count++;
+            }            
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "[" + inclusiveStart + ", " + exclusiveEnd + ")";
+    }
+}

--- a/src/java/searcher/MockRetriever.java
+++ b/src/java/searcher/MockRetriever.java
@@ -1,0 +1,83 @@
+
+package searcher;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+
+
+public class MockRetriever implements Retriever {
+
+    @Override
+    public Query buildQuery(String queryStr) throws Exception {
+        return null;
+    }
+    
+    @Override
+    public TopDocs retrieve(Query query) throws Exception {
+        int totalHits = 1000;
+        ScoreDoc[] scoreDocs = new ScoreDoc[totalHits];
+        TopDocs topDocs = new TopDocs(totalHits, scoreDocs, 0);
+        return topDocs;
+    }
+
+    @Override
+    public JsonObject constructJSONForRetrievedSet(Query query, ScoreDoc[] hits) throws Exception {
+        return constructJSONForRetrievedSet(query, hits, new IntRange(0, hits.length));
+    }
+
+    @Override
+    public JsonObject constructJSONForRetrievedSet(Query query, ScoreDoc[] hits, int pageNum) throws Exception {
+        int start = (pageNum - 1) * 10;
+        int end = start + 10;
+        //int hasMore = end < hits.length ? 1 : 0;
+        //objectBuilder.add("hasmore", hasMore);
+        IntRange range = new IntRange(start, end).limit(0, hits.length);
+        return constructJSONForRetrievedSet(query, hits, range);
+    }
+
+    @Override
+    public JsonObject constructJSONForRetrievedSet(Query query, ScoreDoc[] hits, int start, int howMany) throws Exception {
+        IntRange range = new IntRange(start, start + howMany).limit(0, hits.length);
+        return constructJSONForRetrievedSet(query, hits, range);
+    }
+
+    @Override
+    public JsonObject constructJSONForRetrievedSet(Query query, ScoreDoc[] hits, Iterable<Integer> selection) throws Exception {
+        JsonBuilderFactory factory = Json.createBuilderFactory(null);
+        JsonObjectBuilder objectBuilder = factory.createObjectBuilder();
+        if (hits == null || hits.length == 0) {
+            return objectBuilder.add("error", "Nothing found").build();
+        }
+        objectBuilder.add("numHits", hits.length);
+        JsonArrayBuilder arrayBuilder = factory.createArrayBuilder();
+        for (Integer i : selection) {
+            try {
+                ScoreDoc hit = hits[i];
+                arrayBuilder.add(constructJSONForDoc(query, i));
+            } catch (NullPointerException | IndexOutOfBoundsException e) {}
+        }
+        objectBuilder.add("results", arrayBuilder);
+        return objectBuilder.build();
+    }
+    
+    JsonObjectBuilder constructJSONForDoc(Query q, int docid) throws Exception {
+        JsonBuilderFactory factory = Json.createBuilderFactory(null);
+        
+        JsonObjectBuilder objectBuilder = factory.createObjectBuilder();
+        objectBuilder.add("title", "title-" + docid);
+        objectBuilder.add("snippet", "snippet-" + docid);
+        objectBuilder.add("id", "" + docid);
+        return objectBuilder;
+    }
+
+    @Override
+    public String getHTMLFromDocId(String docId) throws Exception {
+        throw new UnsupportedOperationException("");
+    }  
+}

--- a/src/java/searcher/Retriever.java
+++ b/src/java/searcher/Retriever.java
@@ -1,0 +1,27 @@
+
+package searcher;
+
+import javax.json.JsonObject;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+
+public interface Retriever {
+
+    Query buildQuery(String queryStr) throws Exception;
+
+    JsonObject constructJSONForRetrievedSet(Query query, ScoreDoc[] hits) throws Exception;
+
+    JsonObject constructJSONForRetrievedSet(Query query, ScoreDoc[] hits, int pageNum) throws Exception;
+
+    JsonObject constructJSONForRetrievedSet(Query query, ScoreDoc[] hits, int start, int howMany) throws Exception;
+
+    JsonObject constructJSONForRetrievedSet(Query query, ScoreDoc[] hits, Iterable<Integer> selection) throws Exception;
+
+    // Called when the webapp passes in the docid and is interested
+    // to fetch the content
+    String getHTMLFromDocId(String docId) throws Exception;
+
+    TopDocs retrieve(Query query) throws Exception;
+    
+}

--- a/src/java/servlets/SearchServlet.java
+++ b/src/java/servlets/SearchServlet.java
@@ -3,13 +3,16 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-
 package servlets;
 
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Properties;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonWriter;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -17,9 +20,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import searcher.WT10GRetriever;
 import javax.servlet.http.HttpSession;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import searcher.ClueWebRetriever;
+
 /**
  *
  * @author dganguly
@@ -28,43 +33,39 @@ public class SearchServlet extends HttpServlet {
 
     String propFileName;
     WT10GRetriever retriever;
-    
+
     @Override
     public void init(ServletConfig config) throws ServletException {
         try {
-            propFileName= config.getInitParameter("configFile");
+            propFileName = config.getInitParameter("configFile");
             //retriever = new WT10GRetriever(propFileName);
-            
+
             // Create an object for either WT10G or ClueWeb retriever
             Properties prop = new Properties();
             prop.load(new FileReader(propFileName));
             String retrClassName = prop.getProperty("retriever.type");
-            if (retrClassName.equals("WT10G"))
+            if (retrClassName.equals("WT10G")) {
                 retriever = new WT10GRetriever(propFileName);
-            else
+            } else {
                 retriever = new ClueWebRetriever(propFileName);
-        }
-        catch (Exception ex) {
-            ex.printStackTrace();            
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
         }
     }
-    
-    /* Return the snapshot of the current page */
-    String getPageViewOfResultList(HttpServletRequest request,
-            String query, String pageNumberStr)
+
+    TopDocs getCachedTopDocs(HttpServletRequest request, String queryStr, Query query)
             throws Exception {
-        
-        int pageNumber = Integer.parseInt(pageNumberStr);
+
         HttpSession session = request.getSession();
-        TopDocs topDocs = (TopDocs)session.getAttribute(query);
-        if (topDocs != null) {
-            ScoreDoc[] scoreDocs = topDocs.scoreDocs;
-            return retriever.constructJSONForRetrievedSet(query, scoreDocs, pageNumber);
-        }       
-        topDocs = retriever.retrieve(query, pageNumber);
-        session.setAttribute(query, topDocs);
-        return retriever.constructJSONForRetrievedSet(query, topDocs.scoreDocs, pageNumber);
+        TopDocs topDocs = (TopDocs) session.getAttribute(queryStr);
+        if (topDocs == null) {
+            topDocs = retriever.retrieve(query);
+            session.setAttribute(queryStr, topDocs);
+        }
+        return topDocs;
     }
+
     /**
      * Processes requests for both HTTP <code>GET</code> and <code>POST</code>
      * methods.
@@ -75,28 +76,30 @@ public class SearchServlet extends HttpServlet {
      * @throws IOException if an I/O error occurs
      */
     protected void processRequest(HttpServletRequest request, HttpServletResponse response)
-        throws ServletException, IOException {
-        response.setContentType("text/html;charset=UTF-8");
-        PrintWriter out = response.getWriter();
-        String html = null;
-        try {
+            throws ServletException, IOException {
+        response.setContentType("application/json;charset=UTF-8");
+
+        try (PrintWriter printWriter = response.getWriter();
+            JsonWriter jsonWriter = Json.createWriter(printWriter)) {
+            
             String queryStr = request.getParameter("query");
-			System.out.println("query = |" + queryStr + "|");
+            System.out.println("query = |" + queryStr + "|");
             String pageNum = request.getParameter("page");
-            
+           
+            JsonObject json;
+            Query query = retriever.buildQuery(queryStr);
             if (pageNum == null) { // no pagination workflow
-                html = retriever.retrieve(queryStr);
+                TopDocs topDocs = retriever.retrieve(query);
+                json = retriever.constructJSONForRetrievedSet(query, topDocs.scoreDocs);
+            } else { // pagination workflow
+                int page = Integer.parseUnsignedInt(pageNum);
+                TopDocs topDocs = getCachedTopDocs(request, queryStr, query);
+                json = retriever.constructJSONForRetrievedSet(query, topDocs.scoreDocs, page);
             }
-            else { // pagination workflow
-                html = getPageViewOfResultList(request, queryStr, pageNum);
-            }
-            
-            out.println(html);                
-            out.close();
-        }
-        catch (Exception ex) {
+            jsonWriter.write(json);
+        } catch (Exception ex) {
             ex.printStackTrace();
-        }        
+        }
     }
 
     // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
@@ -110,7 +113,7 @@ public class SearchServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
-        throws ServletException, IOException {
+            throws ServletException, IOException {
         processRequest(request, response);
     }
 
@@ -124,7 +127,7 @@ public class SearchServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
-        throws ServletException, IOException {
+            throws ServletException, IOException {
         processRequest(request, response);
     }
 


### PR DESCRIPTION
I've added two interactions modes with the server: 

> request: search?query= q:String &start= s:int &howMany= h:int 
> response: {"totHits": int , "results":[ r_s:JsonObject , ...,  r_(s+h):JsonObject ]} 
> 
> request: search?query= q:String &selection=[ i_1:int , ...,  i_n:int ]
> response: {"totHits": int , "results":[ r_(i_1):JsonObject , ...,  r_(i_n):JsonObject ]} 

The old ones are still supported but the response format is changed a bit:

> request: search?query= q:String &page= p:int 
> response: {"totHits": int , "results":[ r_p[0]:JsonObject , ...,  r_(p[10]):JsonObject ]} 
> 
> request: search?query= q:String 
> response: {"totHits": int , "results":[ r_0:JsonObject , ...,  r_(tot-1):JsonObject }      

in case of error response is:        

> or {"error": message:String } 
